### PR TITLE
fix: support python specified tag in config file

### DIFF
--- a/easycore/common/config/config.py
+++ b/easycore/common/config/config.py
@@ -187,7 +187,7 @@ class CfgNode(dict):
         Returns:
             CfgNode:
         """
-        cfg_dict = yaml.load(yaml_str, Loader=yaml.FullLoader)
+        cfg_dict = yaml.load(yaml_str, Loader=yaml.UnsafeLoader)
         return cls(cfg_dict)
 
 

--- a/easycore/common/config/config.py
+++ b/easycore/common/config/config.py
@@ -187,7 +187,7 @@ class CfgNode(dict):
         Returns:
             CfgNode:
         """
-        cfg_dict = yaml.safe_load(yaml_str)
+        cfg_dict = yaml.load(yaml_str)
         return cls(cfg_dict)
 
 
@@ -283,7 +283,7 @@ class CfgNode(dict):
             None or str:
         """
         cfg_dict = CfgNode._convert_cfg_to_dict(cfg)
-        return yaml.safe_dump(cfg_dict, stream=stream, encoding=encoding, **kwargs)
+        return yaml.dump(cfg_dict, stream=stream, encoding=encoding, **kwargs)
 
     def dict(self):
         """

--- a/easycore/common/config/config.py
+++ b/easycore/common/config/config.py
@@ -187,7 +187,7 @@ class CfgNode(dict):
         Returns:
             CfgNode:
         """
-        cfg_dict = yaml.load(yaml_str)
+        cfg_dict = yaml.load(yaml_str, Loader=yaml.FullLoader)
         return cls(cfg_dict)
 
 

--- a/test/config/example.yaml
+++ b/test/config/example.yaml
@@ -6,6 +6,7 @@ app:
     version: '0.1.0'
     user_number_range: (0, 100)
     default_user: ['root', 'admin']
+  scale: !!python/object/apply:eval [2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]
 
 docs:
   path: https://XXXXXX.com/docs

--- a/test/config/example.yaml
+++ b/test/config/example.yaml
@@ -6,7 +6,7 @@ app:
     version: '0.1.0'
     user_number_range: (0, 100)
     default_user: ['root', 'admin']
-  scale: !!python/object/apply:eval [2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]
+  scale: !!python/object/apply:eval [ '[2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]' ]
 
 docs:
   path: https://XXXXXX.com/docs

--- a/test/config/test_CfgNode.py
+++ b/test/config/test_CfgNode.py
@@ -79,4 +79,4 @@ class TestCfgNode:
         input_path = os.path.join(FILE_DIR, 'example.yaml')
 
         cfg = CN.open(input_path)
-        assert cfg.scale == [2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]
+        assert cfg.app.scale == [2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]

--- a/test/config/test_CfgNode.py
+++ b/test/config/test_CfgNode.py
@@ -74,3 +74,9 @@ class TestCfgNode:
         
         result = {'A': 1, 'B':{'C': 3}}
         assert cfg_dict == result
+
+    def test_python_specified_tag(self):
+        input_path = os.path.join(FILE_DIR, 'example.yaml')
+
+        cfg = CN.open(input_path)
+        assert cfg.scale == [2 ** 0, 2 ** (1 / 3), 2 ** (2 / 3)]


### PR DESCRIPTION
**fix:**
+ use unsafe `yaml.load` instead of `yaml.safe_load`